### PR TITLE
lsコマンドをつくる ①

### DIFF
--- a/04.ls/.gitignore
+++ b/04.ls/.gitignore
@@ -1,0 +1,1 @@
+test_ls.rb

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -14,10 +14,23 @@ def format_columns(contents, column_number)
 
   # 縦(列)で分割
   columns = sorted_contents.each_slice(row_count).to_a;
+
+  # 縦(列)の幅(列の中で1番長いファイル/ディレクトリの名前の長さ)を決める
+  column_width = columns.map do |col|
+    length_array = col.map do |c|
+      c.length
+    end
+    length_array.max
+  end
   # 横 (行)で分割 (指定した配列の長さまでなかったら最後尾に空白の要素を入れる)
   rows = columns.each{ |col| col[row_count - 1] = " " if col.length < row_count }.transpose
+
+  # 各行ずつ表示していく
   rows.each do |row|
-    puts row.map{|r| r.ljust(10)}.join(" ")
+    row.each_with_index do |item, col_index|
+      print item.ljust(column_width[col_index] + 2)
+    end
+    puts
   end
 end
 

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -18,7 +18,7 @@ def format_columns(contents, column_number)
   rows = columns.transpose
 
   rows.each do |row|
-    puts row.join(" ")
+    puts row.map{|r| r.ljust(10)}.join(" ")
   end
 end
 

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -9,6 +9,7 @@ def display_filenames_table(rows, col_widths)
 end
 
 def format_as_table(contents, col_count)
+  return [[], []] if contents.empty?
   row_count = (contents.size.to_f / col_count).ceil
   columns = contents.sort.each_slice(row_count).map { |col| col.fill('', col.size...row_count) }
   rows = columns.transpose
@@ -16,11 +17,12 @@ def format_as_table(contents, col_count)
   [rows, col_widths]
 end
 
-def display_filenames(col_count = 3)
+def display_filenames(col_count)
   current_directory = Dir.pwd
   contents = Dir.children(current_directory).reject { |name| name.start_with?('.') }
   rows, col_widths = format_as_table(contents, col_count)
   display_filenames_table(rows, col_widths)
 end
 
-display_filenames
+DEFAULT_COLUMN_COUNT = 3
+display_filenames(DEFAULT_COLUMN_COUNT)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -1,31 +1,5 @@
 #!/usr/bin/env ruby
-# 1. カレントディレクトリ取得機能を実装
-current_directory = Dir.pwd
-
-# 2. ディレクトリ内容取得機能を実装
-contents = Dir.children(current_directory)
-row_number = 3
-
-# 3. 表示形式を整える
-def format_columns(contents, column_number)
-  # 要素数から行数を計算
-  row_count = (contents.size.to_f / column_number).ceil
-  sorted_contents = contents.sort
-
-  # 縦(列)で分割
-  columns = sorted_contents.each_slice(row_count).to_a;
-
-  # 縦(列)の幅(列の中で1番長いファイル/ディレクトリの名前の長さ)を決める
-  column_width = columns.map do |col|
-    length_array = col.map do |c|
-      c.length
-    end
-    length_array.max
-  end
-  # 横 (行)で分割 (指定した配列の長さまでなかったら最後尾に空白の要素を入れる)
-  rows = columns.each{ |col| col[row_count - 1] = " " if col.length < row_count }.transpose
-
-  # 各行ずつ表示していく
+def display_table(rows, column_width)
   rows.each do |row|
     row.each_with_index do |item, col_index|
       print item.ljust(column_width[col_index] + 2)
@@ -34,4 +8,25 @@ def format_columns(contents, column_number)
   end
 end
 
-format_columns(contents, row_number);
+def format_table(contents, col_count)
+  row_count = (contents.size.to_f / col_count).ceil
+  sorted_contents = contents.sort
+  columns = sorted_contents.each_slice(row_count).to_a;
+  rows = columns.each{ |col| col[row_count - 1] = " " if col.length < row_count }.transpose
+  column_width = columns.map do |col|
+    length_array = col.map do |c|
+      c.length
+    end
+    length_array.max
+  end
+  [rows, column_width]
+end
+
+def display_directory_listing(col_count = 3)
+  current_directory = Dir.pwd
+  contents = Dir.children(current_directory)
+  rows, widths = format_table(contents, col_count);
+  display_table(rows, widths)
+end
+
+display_directory_listing

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -1,14 +1,14 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-def display_table(rows, column_width)
+def display_filenames_table(rows, col_widths)
   rows.each do |row|
-    print row.each_with_index.map { |item, col_index| item.ljust(column_width[col_index] + 2) }.join
+    print row.each_with_index.map { |item, col_index| item.ljust(col_widths[col_index] + 2) }.join
     puts
   end
 end
 
-def format_table(contents, col_count)
+def format_as_table(contents, col_count)
   row_count = (contents.size.to_f / col_count).ceil
   columns = contents.sort.each_slice(row_count).map { |col| col.fill('', col.size...row_count) }
   rows = columns.transpose
@@ -16,11 +16,11 @@ def format_table(contents, col_count)
   [rows, col_widths]
 end
 
-def display_directory_listing(col_count = 3)
+def display_filenames(col_count = 3)
   current_directory = Dir.pwd
   contents = Dir.children(current_directory).reject { |name| name.start_with?('.') }
-  rows, widths = format_table(contents, col_count)
-  display_table(rows, widths)
+  rows, col_widths = format_as_table(contents, col_count)
+  display_filenames_table(rows, col_widths)
 end
 
-display_directory_listing
+display_filenames

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -4,4 +4,22 @@ current_directory = Dir.pwd
 
 # 2. ディレクトリ内容取得機能を実装
 contents = Dir.children(current_directory)
-puts contents
+row_number = 3
+
+# 3. 表示形式を整える
+def format_columns(contents, column_number)
+  # 要素数から行数を計算
+  row_count = (contents.size.to_f / column_number).ceil
+  sorted_contents = contents.sort
+
+  # 縦(列)で分割
+  columns = sorted_contents.each_slice(row_count).to_a;
+  # 横 (行)で分割
+  rows = columns.transpose
+
+  rows.each do |row|
+    puts row.join(" ")
+  end
+end
+
+format_columns(contents, row_number);

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -1,3 +1,7 @@
 #!/usr/bin/env ruby
 # 1. カレントディレクトリ取得機能を実装
 current_directory = Dir.pwd
+
+# 2. ディレクトリ内容取得機能を実装
+contents = Dir.children(current_directory)
+puts contents

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -14,9 +14,8 @@ def format_columns(contents, column_number)
 
   # 縦(列)で分割
   columns = sorted_contents.each_slice(row_count).to_a;
-  # 横 (行)で分割
-  rows = columns.transpose
-
+  # 横 (行)で分割 (指定した配列の長さまでなかったら最後尾に空白の要素を入れる)
+  rows = columns.each{ |col| col[row_count - 1] = " " if col.length < row_count }.transpose
   rows.each do |row|
     puts row.map{|r| r.ljust(10)}.join(" ")
   end

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -1,25 +1,17 @@
 #!/usr/bin/env ruby
 def display_table(rows, column_width)
   rows.each do |row|
-    row.each_with_index do |item, col_index|
-      print item.ljust(column_width[col_index] + 2)
-    end
+    print row.each_with_index.map {|item, col_index| item.ljust(column_width[col_index] + 2)}.join
     puts
   end
 end
 
 def format_table(contents, col_count)
   row_count = (contents.size.to_f / col_count).ceil
-  sorted_contents = contents.sort
-  columns = sorted_contents.each_slice(row_count).to_a;
-  rows = columns.each{ |col| col[row_count - 1] = " " if col.length < row_count }.transpose
-  column_width = columns.map do |col|
-    length_array = col.map do |c|
-      c.length
-    end
-    length_array.max
-  end
-  [rows, column_width]
+  columns = contents.sort.each_slice(row_count).map { |col| col.fill("", col.size...row_count)}
+  rows = columns.transpose
+  col_widths = columns.map { |col| col.map(&:length).max }
+  [rows, col_widths]
 end
 
 def display_directory_listing(col_count = 3)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -1,0 +1,3 @@
+#!/usr/bin/env ruby
+# 1. カレントディレクトリ取得機能を実装
+current_directory = Dir.pwd

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -18,7 +18,7 @@ end
 
 def display_directory_listing(col_count = 3)
   current_directory = Dir.pwd
-  contents = Dir.children(current_directory)
+  contents = Dir.children(current_directory).reject { |name| name.start_with?('.') }
   rows, widths = format_table(contents, col_count)
   display_table(rows, widths)
 end

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -1,14 +1,16 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 def display_table(rows, column_width)
   rows.each do |row|
-    print row.each_with_index.map {|item, col_index| item.ljust(column_width[col_index] + 2)}.join
+    print row.each_with_index.map { |item, col_index| item.ljust(column_width[col_index] + 2) }.join
     puts
   end
 end
 
 def format_table(contents, col_count)
   row_count = (contents.size.to_f / col_count).ceil
-  columns = contents.sort.each_slice(row_count).map { |col| col.fill("", col.size...row_count)}
+  columns = contents.sort.each_slice(row_count).map { |col| col.fill('', col.size...row_count) }
   rows = columns.transpose
   col_widths = columns.map { |col| col.map(&:length).max }
   [rows, col_widths]
@@ -17,7 +19,7 @@ end
 def display_directory_listing(col_count = 3)
   current_directory = Dir.pwd
   contents = Dir.children(current_directory)
-  rows, widths = format_table(contents, col_count);
+  rows, widths = format_table(contents, col_count)
   display_table(rows, widths)
 end
 

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
+DEFAULT_COLUMN_COUNT = 3
 
 def display_filenames_table(rows, col_widths)
   rows.each do |row|
@@ -11,7 +12,7 @@ end
 def format_as_table(contents, col_count)
   return [[], []] if contents.empty?
   row_count = (contents.size.to_f / col_count).ceil
-  columns = contents.sort.each_slice(row_count).map { |col| col.fill('', col.size...row_count) }
+  columns = contents.each_slice(row_count).map { |col| col.fill('', col.size...row_count) }
   rows = columns.transpose
   col_widths = columns.map { |col| col.map(&:length).max }
   [rows, col_widths]
@@ -19,10 +20,8 @@ end
 
 def display_filenames(col_count)
   current_directory = Dir.pwd
-  contents = Dir.children(current_directory).reject { |name| name.start_with?('.') }
+  contents = Dir.children(current_directory).reject { |name| name.start_with?('.') }.sort
   rows, col_widths = format_as_table(contents, col_count)
   display_filenames_table(rows, col_widths)
 end
-
-DEFAULT_COLUMN_COUNT = 3
 display_filenames(DEFAULT_COLUMN_COUNT)


### PR DESCRIPTION
#  したいこと
1. カレントディレクトリを取得
2. カレントディレクトリ内のファイル/ディレクトリを取得
3. 取得したカレントディレクトリの中身を表示

# したこと (関数別)
## 1. カレントディレクトリの中身を取得 (display_table)
Dirクラスを使用した。

## 2. 表示のフォーマット調整 (format_table)
- 行数の計算
- 列に空欄がある場合は、空欄にする
- 行列の転置
- 列の中で1番長い文字列に幅を合わせる

## 3. 一覧の表示 (display_directory_listing)
- 列の中で1番文字列が長いファイル/ディレクトリの幅に合わせて、各行のファイル/ディレクトリを表示
- 列数が引数で指定できるようにした。