### PR TITLE
lsコマンドをつくる③ : -r オプション

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,4 @@ $RECYCLE.BIN/
 
 # Windows shortcuts
 *.lnk
+.commit_template

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -24,6 +24,7 @@ end
 def display_filenames(col_count, options)
   current_directory = Dir.pwd
   contents = Dir.entries(current_directory).sort
+  contents = contents.reverse if options[:r]
   contents = contents.reject { |name| name.start_with?('.') } unless options[:a]
   rows, col_widths = format_as_table(contents, col_count)
   display_filenames_table(rows, col_widths)
@@ -31,12 +32,12 @@ end
 
 def extract_options
   options = {
-    a: false
+    a: false,
+    r: false
   }
   opts = OptionParser.new do |opt|
-    opt.on('-a', 'Show all files') do
-      options[:a] = true
-    end
+    opt.on('-a', 'Show all files') { options[:a] = true }
+    opt.on('-r', 'Reverse file order') { options[:r] = true }
   end
   opts.parse!
   options


### PR DESCRIPTION
# したいこと
lsコマンドの```r```オプションを追加し、表示されるファイルやディレクトリの順が通常と逆順に表示させるようにする。

# したこと
- rオプションの追加
- reverseメソッドを使い、逆順に表示
